### PR TITLE
Update elasticsearch service to use community image.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     ports:
       - 8025:8025
   elasticsearch:
-    image: forumone/elasticsearch-oss:aws-7.8
+    image: elasticsearch:7.8.1
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
Update the elasticsearch service to use the community image since `forumone/elasticsearch-oss` will be taken offline soon.